### PR TITLE
Add @MainActor to ViewModelOwner Protocols

### DIFF
--- a/Sources/Core/ViewModelOwner.swift
+++ b/Sources/Core/ViewModelOwner.swift
@@ -11,7 +11,7 @@ private enum ViewModelOwnerKeys {
 }
 
 ///  ViewModelOwner that doesn't support reuse, it doesn't support setting nil and will `fatalError` upon trying to access misconfigured view model.
-public protocol NonReusableViewModelOwner: AnyObject {
+@MainActor public protocol NonReusableViewModelOwner: AnyObject {
 
     /// Associated type of ViewModel.
     associatedtype ViewModelProtocol
@@ -42,7 +42,7 @@ public protocol NonReusableViewModelOwner: AnyObject {
 
 
 /// ViewModelOwner that allows reuse, it allows setting nil view models and automatically unregisters registrations on new values.
-public protocol ReusableViewModelOwner: AnyObject {
+@MainActor public protocol ReusableViewModelOwner: AnyObject {
 
     /// Associated type of ViewModel.
     associatedtype ViewModelProtocol


### PR DESCRIPTION
Hi, 

I'm trying to adopt Swift 6 Concurrency in my app and the question comes up how to correctly deal with it in regards to ViewModelOwners.

I have made my ViewControllers `@MainActors` - Now I get warnings at `didSetViewModel`

>Main actor-isolated instance method 'didSetViewModel(_:disposeBag:)' cannot be used to satisfy nonisolated requirement from protocol 'NonReusableViewModelOwner'; this is an error in the Swift 6 language mode

I guess it would be correct to add @MainActor to the ViewModelOwner Protocols as well since these operations should always happen on the main thread?